### PR TITLE
remove old symlink

### DIFF
--- a/archives/2016-2017/exercises/javascript/lesson5/exercise3/.#README.md
+++ b/archives/2016-2017/exercises/javascript/lesson5/exercise3/.#README.md
@@ -1,1 +1,0 @@
-marin@localhost.localdomain.5175:1483009095


### PR DESCRIPTION
The symlink was in `./archives/2016-2017/exercises/javascript/lesson5/exercise3/.#README.md`
it closes issue #9 .
Merci beaucoup!!
flo